### PR TITLE
build: make the docker image smaller

### DIFF
--- a/deployment-notifier/Dockerfile
+++ b/deployment-notifier/Dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.21-alpine
+FROM golang:1.21-alpine as build
 
 WORKDIR /app
 
-COPY go.* .
+COPY go.* ./
+RUN go mod download
+
 COPY main.go .
 
-RUN go build -o /notifier
+RUN CGO_ENABLED=0 go build -trimpath -o /notifier
 
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /notifier /notifier
 EXPOSE 8443
-
-CMD ["/notifier"]
+CMD [ "/notifier" ]


### PR DESCRIPTION
This leaves all building dependencies and cached items out of the final docker image. The final image will be much smaller in size.